### PR TITLE
Fix duplicate Statsig page load logging

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,23 +7,20 @@ import { STATSIG_CLIENT_KEY } from '@/constants/apiKeys';
 import { trackGAEvent } from '@/lib/ga';
 import { createStatsigLogger } from '@/lib/statsig-debug';
 import { getStableUserID } from '@/utils/getStableUserID';
-import { StatsigProvider, useClientAsyncInit, useStatsigClient } from '@statsig/react-bindings';
-import { useEffect } from 'react';
+import { StatsigProvider, useStatsigClient } from '@statsig/react-bindings';
+import { useEffect, useMemo } from 'react';
 
 function PageWithStatsig() {
-  const { isLoading } = useClientAsyncInit(STATSIG_CLIENT_KEY, {
-    userID: getStableUserID(),
-  });
-  const statsig = useStatsigClient();
-  const statsigLogger = createStatsigLogger(statsig);
+  const { client: statsigClient, isLoading } = useStatsigClient();
+  const statsigLogger = useMemo(() => createStatsigLogger(statsigClient), [statsigClient]);
 
   useEffect(() => {
-    if (!isLoading && statsig) {
+    if (!isLoading && statsigClient) {
       const path = typeof window !== 'undefined' ? window.location.pathname : '/';
       statsigLogger.logEvent('page_loaded', 1, { path });
       trackGAEvent('page_loaded', { path });
     }
-  }, [isLoading, statsig, statsigLogger]);
+  }, [isLoading, statsigClient, statsigLogger]);
 
   if (isLoading) return null;
 


### PR DESCRIPTION
## Summary
- create a memoized Statsig logger derived from the active client
- rely on the Statsig provider context for initialization state to avoid repeated `page_loaded` events

## Testing
- pnpm lint *(fails: Next.js prompted for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c8f66a9083209c8bab8b531208d3